### PR TITLE
Allow queries with "tag=*" tag filters in expressions

### DIFF
--- a/src/core/PostAggregatedDataPoints.java
+++ b/src/core/PostAggregatedDataPoints.java
@@ -4,9 +4,11 @@
  */
 package net.opentsdb.core;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Maps;
 import com.stumbleupon.async.Deferred;
 import net.opentsdb.meta.Annotation;
 
@@ -15,6 +17,8 @@ public class PostAggregatedDataPoints implements DataPoints {
   private final DataPoints baseDataPoints;
   private final DataPoint[] points;
 
+  private String alias = null;
+
   public PostAggregatedDataPoints(DataPoints baseDataPoints, DataPoint[] points) {
     this.baseDataPoints = baseDataPoints;
     this.points = points;
@@ -22,27 +26,36 @@ public class PostAggregatedDataPoints implements DataPoints {
 
   @Override
   public String metricName() {
-    return baseDataPoints.metricName();
+    if (alias != null) return alias;
+    else return baseDataPoints.metricName();
   }
 
   @Override
   public Deferred<String> metricNameAsync() {
+    if (alias != null) return Deferred.fromResult(alias);
     return baseDataPoints.metricNameAsync();
   }
 
   @Override
   public Map<String, String> getTags() {
-    return baseDataPoints.getTags();
+    if (alias != null) return Maps.newHashMap();
+    else return baseDataPoints.getTags();
   }
 
   @Override
   public Deferred<Map<String, String>> getTagsAsync() {
+    Map<String, String> def = new HashMap<String, String>();
+    if (alias != null) return Deferred.fromResult(def);
     return baseDataPoints.getTagsAsync();
   }
 
   @Override
   public List<String> getAggregatedTags() {
     return baseDataPoints.getAggregatedTags();
+  }
+
+  public void setAlias(String alias) {
+    this.alias = alias;
   }
 
   @Override

--- a/src/tsd/GraphHandler.java
+++ b/src/tsd/GraphHandler.java
@@ -113,6 +113,13 @@ final class GraphHandler implements HttpRpc {
   }
 
   public void execute(final TSDB tsdb, final HttpQuery query) {
+
+
+    float f1 = Float.parseFloat("0.35");
+    float f2 = Float.parseFloat("0.65");
+    float n = Float.parseFloat("0.00035");
+    LOG.info("result = " + (n / (1 - (f2 + f1 + 0))));
+
     if (!query.hasQueryStringParam("json")
         && !query.hasQueryStringParam("png")
         && !query.hasQueryStringParam("ascii")) {

--- a/src/tsd/HttpJsonSerializer.java
+++ b/src/tsd/HttpJsonSerializer.java
@@ -726,7 +726,7 @@ class HttpJsonSerializer extends HttpSerializer {
 			json.writeStartObject();
 
       if (expression != null) {
-        json.writeStringField("expression", expression.writeStringField());
+        json.writeStringField("expression", dps.metricName());
       } else {
         json.writeStringField("metric", dps.metricName());
       }

--- a/src/tsd/expression/ExpressionFactory.java
+++ b/src/tsd/expression/ExpressionFactory.java
@@ -1,15 +1,23 @@
 package net.opentsdb.tsd.expression;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
+import net.opentsdb.core.DataPoint;
 import net.opentsdb.core.DataPoints;
 import net.opentsdb.core.Functions;
+import net.opentsdb.core.MutableDataPoint;
+import net.opentsdb.core.PostAggregatedDataPoints;
 import net.opentsdb.core.TSQuery;
+import org.apache.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class ExpressionFactory {
+
+  private static final Logger logger = Logger.getLogger(ExpressionFactory.class);
 
   private static Map<String, Expression> availableFunctions =
           Maps.newHashMap();
@@ -57,6 +65,8 @@ public class ExpressionFactory {
 
   static class AliasFunction implements Expression {
 
+    static Joiner COMMA_JOINER = Joiner.on(',').skipNulls();
+
     @Override
     public DataPoints[] evaluate(TSQuery data_query, List<DataPoints[]> queryResults,
                                  List<String> queryParams) {
@@ -64,7 +74,49 @@ public class ExpressionFactory {
         throw new NullPointerException("No query results");
       }
 
-      return queryResults.get(0);
+      String aliasTemplate = "__default";
+
+      if (queryParams != null && queryParams.size() >= 0) {
+        aliasTemplate = COMMA_JOINER.join(queryParams);
+      }
+
+      DataPoints[] inputPoints = queryResults.get(0);
+
+      DataPoint[][] dps = new DataPoint[inputPoints.length][];
+
+      for (int j=0; j<dps.length; j++) {
+        DataPoints base = inputPoints[j];
+        dps[j] = new DataPoint[base.size()];
+        int i = 0;
+
+        for (DataPoint pt : base) {
+          if (pt.isInteger()) {
+            dps[j][i] = MutableDataPoint.ofDoubleValue(pt.timestamp(), pt.longValue());
+          } else {
+            dps[j][i] = MutableDataPoint.ofDoubleValue(pt.timestamp(), pt.doubleValue());
+          }
+          i++;
+        }
+      }
+
+      logger.info(", queryResults.size=" + queryResults.size()
+              + ", queryResults(0).length=" + inputPoints.length);
+
+      DataPoints[] resultArray = new DataPoints[queryResults.get(0).length];
+      for (int i=0; i<resultArray.length; i++) {
+        PostAggregatedDataPoints result = new PostAggregatedDataPoints(inputPoints[i],
+                dps[i]);
+
+        String alias = aliasTemplate;
+        for (Map.Entry<String, String> e: inputPoints[i].getTags().entrySet()) {
+          alias = alias.replace("@" + e.getKey(), e.getValue());
+        }
+
+        result.setAlias(alias);
+        resultArray[i] = result;
+      }
+
+      return resultArray;
     }
 
     @Override

--- a/src/tsd/expression/parser/SyntaxChecker.java
+++ b/src/tsd/expression/parser/SyntaxChecker.java
@@ -39,7 +39,7 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
     PARAMETER(tree, paramIndex++);
     label_1:
     while (true) {
-      if (jj_2_1(2)) {
+      if (jj_2_1(5)) {
         ;
       } else {
         break label_1;
@@ -54,13 +54,13 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
 
   final public void PARAMETER(ExpressionTree tree, int paramIndex) throws ParseException {
                                                        String metric; Token param; ExpressionTree subTree;
-    if (jj_2_2(2)) {
+    if (jj_2_2(5)) {
       subTree = EXPRESSION();
                               tree.addSubExpression(subTree, paramIndex);
-    } else if (jj_2_3(2)) {
+    } else if (jj_2_3(5)) {
       metric = METRIC();
                          metricQueries.add(metric); tree.addSubMetricQuery(metric, metricQueries.size()-1, paramIndex);
-    } else if (jj_2_4(2)) {
+    } else if (jj_2_4(5)) {
       param = jj_consume_token(NAME);
                       tree.addFunctionParameter(param.image);
     } else {
@@ -77,14 +77,14 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
     agg = jj_consume_token(NAME);
     jj_consume_token(10);
                                             builder.append(agg.image).append(":");
-    if (jj_2_5(2)) {
+    if (jj_2_5(5)) {
       itvl = jj_consume_token(NAME);
       jj_consume_token(10);
                                            builder.append(itvl.image).append(":");
     } else {
       ;
     }
-    if (jj_2_6(2)) {
+    if (jj_2_6(5)) {
       rate = jj_consume_token(NAME);
       jj_consume_token(10);
                                            builder.append(rate.image).append(":");
@@ -93,7 +93,7 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
     }
     metric = jj_consume_token(NAME);
                                         builder.append(metric.image);
-    if (jj_2_8(2)) {
+    if (jj_2_8(5)) {
       jj_consume_token(11);
       tagk = jj_consume_token(NAME);
       jj_consume_token(12);
@@ -101,7 +101,7 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
                                                           tagPairs.add(tagk+"="+tagv);
       label_2:
       while (true) {
-        if (jj_2_7(2)) {
+        if (jj_2_7(5)) {
           ;
         } else {
           break label_2;
@@ -179,6 +179,14 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
   private boolean jj_3_8() {
     if (jj_scan_token(11)) return true;
     if (jj_scan_token(NAME)) return true;
+    if (jj_scan_token(12)) return true;
+    if (jj_scan_token(NAME)) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_7()) { jj_scanpos = xsp; break; }
+    }
+    if (jj_scan_token(13)) return true;
     return false;
   }
 
@@ -203,6 +211,14 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
   private boolean jj_3R_5() {
     if (jj_scan_token(NAME)) return true;
     if (jj_scan_token(10)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_5()) jj_scanpos = xsp;
+    xsp = jj_scanpos;
+    if (jj_3_6()) jj_scanpos = xsp;
+    if (jj_scan_token(NAME)) return true;
+    xsp = jj_scanpos;
+    if (jj_3_8()) jj_scanpos = xsp;
     return false;
   }
 
@@ -237,11 +253,20 @@ public class SyntaxChecker implements SyntaxCheckerConstants {
   private boolean jj_3R_4() {
     if (jj_scan_token(NAME)) return true;
     if (jj_scan_token(7)) return true;
+    if (jj_3R_3()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_1()) { jj_scanpos = xsp; break; }
+    }
+    if (jj_scan_token(9)) return true;
     return false;
   }
 
   private boolean jj_3_7() {
     if (jj_scan_token(8)) return true;
+    if (jj_scan_token(NAME)) return true;
+    if (jj_scan_token(12)) return true;
     if (jj_scan_token(NAME)) return true;
     return false;
   }

--- a/src/tsd/expression/parser/SyntaxCheckerTest.java
+++ b/src/tsd/expression/parser/SyntaxCheckerTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Turn Inc. All Rights Reserved.
+ * Proprietary and confidential.
+ */
+package net.opentsdb.tsd.expression.parser;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.opentsdb.core.TSQuery;
+import net.opentsdb.tsd.expression.ExpressionTree;
+
+public class SyntaxCheckerTest {
+
+	public static void main(String[] args) {
+		try {
+			StringReader r = new StringReader("sum(sum:proc.stat.cpu.percpu{cpu=1})");
+			SyntaxChecker checker = new SyntaxChecker(r);
+			TSQuery query = new TSQuery();
+			List<String> metrics = new ArrayList<String>();
+			checker.setTSQuery(query);
+			checker.setMetricQueries(metrics);
+			ExpressionTree tree = checker.EXPRESSION();
+			System.out.println("Syntax is okay. ExprTree=" + tree);
+			System.out.println("Metrics=" + metrics);
+		} catch (Throwable e) {
+			System.out.println("Syntax check failed: " + e);
+		}
+	}
+}

--- a/src/tsd/expression/parser/SyntaxCheckerTokenManager.java
+++ b/src/tsd/expression/parser/SyntaxCheckerTokenManager.java
@@ -77,7 +77,7 @@ private int jjMoveStringLiteralDfa1_0(long active0)
 private int jjMoveNfa_0(int startState, int curPos)
 {
    int startsAt = 0;
-   jjnewStateCnt = 1;
+   jjnewStateCnt = 2;
    int i = 1;
    jjstateSet[0] = startState;
    int kind = 0x7fffffff;
@@ -93,10 +93,23 @@ private int jjMoveNfa_0(int startState, int curPos)
             switch(jjstateSet[--i])
             {
                case 0:
+                  if ((0x3ffe08800000000L & l) != 0L)
+                  {
+                     if (kind > 5)
+                        kind = 5;
+                     jjCheckNAdd(1);
+                  }
+                  else if (curChar == 42)
+                  {
+                     if (kind > 5)
+                        kind = 5;
+                  }
+                  break;
+               case 1:
                   if ((0x3ffe08800000000L & l) == 0L)
                      break;
                   kind = 5;
-                  jjstateSet[jjnewStateCnt++] = 0;
+                  jjCheckNAdd(1);
                   break;
                default : break;
             }
@@ -110,10 +123,11 @@ private int jjMoveNfa_0(int startState, int curPos)
             switch(jjstateSet[--i])
             {
                case 0:
+               case 1:
                   if ((0x17fffffeafffffffL & l) == 0L)
                      break;
                   kind = 5;
-                  jjstateSet[jjnewStateCnt++] = 0;
+                  jjCheckNAdd(1);
                   break;
                default : break;
             }
@@ -138,7 +152,7 @@ private int jjMoveNfa_0(int startState, int curPos)
          kind = 0x7fffffff;
       }
       ++curPos;
-      if ((i = jjnewStateCnt) == (startsAt = 1 - (jjnewStateCnt = startsAt)))
+      if ((i = jjnewStateCnt) == (startsAt = 2 - (jjnewStateCnt = startsAt)))
          return curPos;
       try { curChar = input_stream.readChar(); }
       catch(java.io.IOException e) { return curPos; }
@@ -163,8 +177,8 @@ static final long[] jjtoSkip = {
    0x1eL, 
 };
 protected SimpleCharStream input_stream;
-private final int[] jjrounds = new int[1];
-private final int[] jjstateSet = new int[2];
+private final int[] jjrounds = new int[2];
+private final int[] jjstateSet = new int[4];
 protected char curChar;
 /** Constructor. */
 public SyntaxCheckerTokenManager(SimpleCharStream stream){
@@ -191,7 +205,7 @@ private void ReInitRounds()
 {
    int i;
    jjround = 0x80000001;
-   for (i = 1; i-- > 0;)
+   for (i = 2; i-- > 0;)
       jjrounds[i] = 0x80000000;
 }
 

--- a/src/tsd/expression/parser/SyntaxCheckerTokenManager.java
+++ b/src/tsd/expression/parser/SyntaxCheckerTokenManager.java
@@ -93,7 +93,7 @@ private int jjMoveNfa_0(int startState, int curPos)
             switch(jjstateSet[--i])
             {
                case 0:
-                  if ((0x3ffe08800000000L & l) != 0L)
+                  if ((0x3ffe09800000000L & l) != 0L)
                   {
                      if (kind > 5)
                         kind = 5;
@@ -106,7 +106,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   }
                   break;
                case 1:
-                  if ((0x3ffe08800000000L & l) == 0L)
+                  if ((0x3ffe09800000000L & l) == 0L)
                      break;
                   kind = 5;
                   jjCheckNAdd(1);

--- a/src/tsd/expression/parser/parser.jj
+++ b/src/tsd/expression/parser/parser.jj
@@ -35,7 +35,7 @@ public class SyntaxChecker {
 PARSER_END(SyntaxChecker)
 
 SKIP:  { " " | "\t" | "\n" | "\r"                    }
-TOKEN: { <NAME: ("*" | (["a" - "z"] | ["A" - "Z"]| ["0"-"9"] | "-" | "_" | "#" | "/" | "@" | "|" | "." | "'" | "]" | "[")+ )> }
+TOKEN: { <NAME: ("*" | (["a" - "z"] | ["A" - "Z"]| ["0"-"9"] | "-" | "_" | "#" | "/" | "$" | "@" | "|" | "." | "'" | "]" | "[")+ )> }
 TOKEN: { <PARAM: ("&&")> }
 
 ExpressionTree EXPRESSION():  {Token name; int paramIndex=0;}  {

--- a/src/tsd/expression/parser/parser.jj
+++ b/src/tsd/expression/parser/parser.jj
@@ -35,7 +35,7 @@ public class SyntaxChecker {
 PARSER_END(SyntaxChecker)
 
 SKIP:  { " " | "\t" | "\n" | "\r"                    }
-TOKEN: { <NAME: (["a" - "z"] | ["A" - "Z"]| ["0"-"9"] | "-" | "_" | "#" | "/" | "@" | "|" | "." | "'" | "]" | "[")+> }
+TOKEN: { <NAME: ("*" | (["a" - "z"] | ["A" - "Z"]| ["0"-"9"] | "-" | "_" | "#" | "/" | "@" | "|" | "." | "'" | "]" | "[")+ )> }
 TOKEN: { <PARAM: ("&&")> }
 
 ExpressionTree EXPRESSION():  {Token name; int paramIndex=0;}  {

--- a/src/tsd/expression/parser/run_javacc.sh
+++ b/src/tsd/expression/parser/run_javacc.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+javacc -STATIC:false -LOOKAHEAD:5 parser.jj


### PR DESCRIPTION
This was previously not supported because if you need this, you can use the regular TSDB interface. But with some graphite functions (for example, highestMax), this feature would be useful.
